### PR TITLE
Fix: chrony.conf template python 3 incompatibility

### DIFF
--- a/templates/chrony.conf.j2
+++ b/templates/chrony.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-{% for command, value in chrony_commands.iteritems()|sort %}
+{% for command, value in chrony_commands.items()|sort %}
 {%   if value is sameas true %}
 {{ command }}
 {%   elif value is string or value is number %}


### PR DESCRIPTION
`items` is defined on a dictionary object in both python 2 and 3.
In 3 it is an efficient iterator while copying is used in python 2.
This, however, has a negligent penalty in this application since the `chrony_commands` dictionary is so small.

Fixes #1.